### PR TITLE
Fix hardcoded time

### DIFF
--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,3 +1,4 @@
+from requests import get
 from deta.base import FetchResponse
 import datetime
 import os
@@ -258,7 +259,7 @@ def get_expire_in(expire_in):
 async def test_ttl(db, items):
     item1 = items[0]
     expire_in = 300
-    expire_at = datetime.datetime(2022, 3, 1, 12, 30, 30)
+    expire_at = datetime.datetime.now() + datetime.timedelta(seconds=expire_in)
     delta = 2  # allow time delta of 2 seconds
     test_cases = [
         {

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -382,7 +382,7 @@ class TestBaseMethods(unittest.TestCase):
 
     def test_ttl(self):
         expire_in = 300
-        expire_at = datetime.datetime(2022, 3, 1, 12, 30, 30)
+        expire_at = datetime.datetime.now() + datetime.timedelta(seconds=expire_in)
         delta = 2  # allow time delta of 2 seconds
         test_cases = [
             {


### PR DESCRIPTION
Replace hardcoded time in expire tests with autogenerated